### PR TITLE
Add FoldingText.app dev version

### DIFF
--- a/Casks/foldingtext-dev.rb
+++ b/Casks/foldingtext-dev.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'foldingtext-dev' do
+  version :latest
+  sha256 :no_check
+
+  # amazonaws.com is the official download host per the vendor homepage
+  url 'http://foldingtext.s3.amazonaws.com/FoldingText-Dev.dmg'
+  name 'FoldingText'
+  homepage 'http://www.foldingtext.com'
+  license :commercial
+
+  app 'FoldingText.app'
+end


### PR DESCRIPTION
Added the development version of FoldingText to as a new cask.FoldingText dev versions use a single download link so this cask will always be up to date unless the download URL is changed.